### PR TITLE
Fix low pop

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -614,6 +614,10 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
 
     if (maxTotalItems == 0  || totalAuctions >= maxTotalItems)
     {
+        if (config->DebugOutSeller)
+        {
+            LOG_INFO("module", "AHBot [{}]: Total auctions {} is above maximum limit {}, exiting loop", _id, totalAuctions, maxTotalItems);
+        }
         return;
     }
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1747,8 +1747,8 @@ void AuctionHouseBot::Initialize(AHBConfig* allianceConfig, AHBConfig* hordeConf
     }
 
     // Share the loaded price overrides across all configurations
-    //_allianceConfig->itemPriceOverrides = _neutralConfig->itemPriceOverrides;
-    //_hordeConfig->itemPriceOverrides = _neutralConfig->itemPriceOverrides;
+    _allianceConfig->itemPriceOverrides = _neutralConfig->itemPriceOverrides;
+    _hordeConfig->itemPriceOverrides = _neutralConfig->itemPriceOverrides;
 }
 
 // Helper function to join GUIDs into a comma-separated string


### PR DESCRIPTION
Add debug log and enable price override sharing to other configs.

Introduced a debug log for auction limit checks and re-enabled sharing of price overrides across configurations to improve debugging and functionality consistency.

## Changes
Added a debug log in AuctionHouseBot::Sell to output when the auction limit is exceeded.
Uncommented and enabled price override sharing in AuctionHouseBot::Initialize for Alliance and Horde configurations.
Modified file: src/AuctionHouseBot.cpp.

## Impact
Behavioral changes: Debug messages will now be logged when the auction limit is exceeded (if DebugOutSeller is enabled). Alliance and Horde configurations will share price overrides with Neutral configuration.
Dependencies affected: Relies on AHBConfig structure and associated logging system.
Breaking changes: None identified.
Performance implications: Minimal, as changes primarily affect logging and configuration initialization.