### PR TITLE
Fix -Werror unused-parameter build break in AuctionHouseBot

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -84,7 +84,7 @@ AuctionHouseBot::~AuctionHouseBot()
     // Nothing
 }
 
-uint32 AuctionHouseBot::getElement(const std::vector<uint32>& vec, int index, uint32 botId, uint32 maxDup, std::unordered_map<uint32, uint32>& botItemCounts)
+uint32 AuctionHouseBot::getElement(const std::vector<uint32>& vec, int index, uint32 /* botId */, uint32 maxDup, std::unordered_map<uint32, uint32>& botItemCounts)
 {
     if (index < 0 || index >= static_cast<int>(vec.size()))
         return 0;
@@ -1129,7 +1129,7 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
 // Get Prioritized ItemIDs
 // =============================================================================
 
-std::vector<uint32> AuctionHouseBot::GetItemsToSell(AHBConfig* config, ObjectGuid botGuid, const std::unordered_set<uint32>& itemsInAH)
+std::vector<uint32> AuctionHouseBot::GetItemsToSell(AHBConfig* config, ObjectGuid /* botGuid */, const std::unordered_set<uint32>& itemsInAH)
 {
     //std::vector<uint32> prioritizedItemIDs;
     std::vector<uint32> allItemIDs;

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -249,8 +249,6 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
         return;
     }
 
-    uint32 guid = AHBplayer->GetGUID().GetCounter();
-
     uint32 bidsPerInterval = 1;
     if (config == _allianceConfig)
     {
@@ -608,7 +606,6 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
     // Check the given limits
     //
     uint32 totalAuctions = getTotalAuctions(config, auctionHouse);
-    uint32 minTotalItems = config->GetMinItems();
     uint32 maxTotalItems = config->GetMaxItems();
     uint32 maxItemsToList = 0;
 
@@ -650,7 +647,6 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
     // Divide maxItems by the number of bots to get the max items per bot
     uint32 numBots = config->GetBotGUIDs().size();
     uint32 maxAuctionsPerBot = (maxTotalItems + numBots - 1) / numBots;
-    uint32 minAuctionsPerBot = (minTotalItems + numBots - 1) / numBots;
 
     bool   aboveMax=false;
 
@@ -685,9 +681,6 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
     {
         LOG_INFO("module", "AHBot [{}]: Trying to list {} items", _id, nbItemsToSellThisCycle);
     }
-
-    // Use the max stack size configuration value
-    uint32 maxStackSize = config->GetMaxStackSize();
 
     // Retrieve the configuration for this run
     //


### PR DESCRIPTION
## Problem

The core build fails (`-Werror -Wunused-parameter`, clang-18):

```
src/AuctionHouseBot.cpp:87:86: fatal error: unused parameter 'botId' [-Wunused-parameter]
```

This is pre-existing (the flagged code dates to 2025-05-21) and became fatal with the stricter flags from the recent azerothcore master merge. `-ferror-limit=1` only surfaces the first one; a scan of the module found a second identical case.

## Fix

Two named-but-unused parameters, unnamed following the module's own existing convention (see `AuctionHouseBotAuctionHouseScript.cpp`, which already unnames unused hook params):

- `AuctionHouseBot::getElement` — `uint32 botId` (dedup keys on the `botItemCounts` map, not `botId`)
- `AuctionHouseBot::GetItemsToSell` — `ObjectGuid botGuid` (body uses the `_id` member instead)

No behavior change; both parameters were already dead code.