### PR TITLE
Sentinel-verified redeploy detection in price-backfill

### DIFF
--- a/tools/price-backfill/README.md
+++ b/tools/price-backfill/README.md
@@ -38,7 +38,18 @@ Smoke test first with `--limit 50`.
 ## Tuning
 
 `--price-scale` (default 1.0), `--min-item-count` (1), `--max-age-days` (180),
-`--deviation-factor` (1.5), `--concurrency` (6), `--rate-delay` (0.15s).
+`--deviation-factor` (1.5), `--concurrency` (6), `--rate-delay` (0.15s),
+`--redeploy-threshold` (25), `--sentinel-id` (4389).
+
+## Redeploy detection
+
+wowauctions.net is a Next.js app whose `buildId` changes on redeploy, which makes
+the old data URLs 404. Since roughly half of WotLK items also legitimately have no
+ChromieCraft data (a normal 404), the tool cannot treat a raw 404 streak as a
+redeploy. After `--redeploy-threshold` consecutive 404s it checks a known-good
+`--sentinel-id` (default 4389, Gyrochronatom): only if that item also 404s is the
+buildId re-resolved and a scoped recovery re-fetch triggered. This prevents a
+no-data streak from causing a re-resolve storm that rate-limits the site.
 
 ## Tests
 

--- a/tools/price-backfill/backfill.py
+++ b/tools/price-backfill/backfill.py
@@ -40,11 +40,12 @@ def load_checkpoint(path):
 class BuildIdState:
     """Thread-safe buildId holder with redeploy re-resolution."""
 
-    def __init__(self, build_id):
+    def __init__(self, build_id, sentinel_id=4389):
         self._lock = threading.Lock()
         self.build_id = build_id
         self.generation = 0
         self.consecutive_404 = 0
+        self.sentinel_id = sentinel_id  # known-good item; confirms a real redeploy
 
     def snapshot(self):
         with self._lock:
@@ -52,14 +53,31 @@ class BuildIdState:
 
     def note_result(self, was_404, threshold):
         with self._lock:
-            if was_404:
-                self.consecutive_404 += 1
-                if self.consecutive_404 >= threshold:
-                    self.build_id = wowauctions.resolve_build_id()
-                    self.generation += 1
-                    self.consecutive_404 = 0
-            else:
+            if not was_404:
                 self.consecutive_404 = 0
+                return self.build_id
+            self.consecutive_404 += 1
+            if self.consecutive_404 < threshold:
+                return self.build_id
+            # A run of 404s usually just means a stretch of items ChromieCraft has
+            # no data for -- NOT a site redeploy. Confirm with a known-good sentinel
+            # item: only a genuine redeploy makes the current buildId 404 for an
+            # item that always has data. This stops no-data streaks from triggering
+            # a needless buildId re-resolve storm and recovery re-fetch.
+            self.consecutive_404 = 0
+            try:
+                sentinel = wowauctions.fetch_item(self.build_id, self.sentinel_id)
+            except Exception:
+                return self.build_id  # transient error; do not assume redeploy
+            if sentinel is not None:
+                return self.build_id  # sentinel still resolves -> buildId is fine
+            # Sentinel 404s under the current buildId -> real redeploy. Re-resolve,
+            # and bump the generation only if the buildId actually changed, so the
+            # recovery pass stays scoped to items fetched under the stale buildId.
+            new_build_id = wowauctions.resolve_build_id()
+            if new_build_id != self.build_id:
+                self.build_id = new_build_id
+                self.generation += 1
             return self.build_id
 
 
@@ -141,7 +159,10 @@ def main():
     p.add_argument("--deviation-factor", type=float, default=1.5)
     p.add_argument("--concurrency", type=int, default=6)
     p.add_argument("--rate-delay", type=float, default=0.15)
-    p.add_argument("--redeploy-threshold", type=int, default=25)
+    p.add_argument("--redeploy-threshold", type=int, default=25,
+                   help="consecutive 404s before a sentinel check for a real redeploy")
+    p.add_argument("--sentinel-id", type=int, default=4389,
+                   help="known-good item id used to confirm a real site redeploy")
     p.add_argument("--limit", type=int, default=0)
     args = p.parse_args()
 
@@ -160,7 +181,7 @@ def main():
     todo = [i for i in ids if i not in done]
     print("candidates={} already_done={} todo={}".format(len(ids), len(done), len(todo)))
 
-    state = BuildIdState(wowauctions.resolve_build_id())
+    state = BuildIdState(wowauctions.resolve_build_id(), sentinel_id=args.sentinel_id)
     ckpt_lock = threading.Lock()
     mode = "a" if args.resume else "w"
     with open(args.checkpoint, mode, encoding="utf-8") as ckpt_fh:

--- a/tools/price-backfill/test_backfill.py
+++ b/tools/price-backfill/test_backfill.py
@@ -74,20 +74,59 @@ class SelectRecoveryIdsTest(unittest.TestCase):
 
 
 class NoteResultTest(unittest.TestCase):
-    def test_note_result_reresolves_at_threshold(self):
-        orig = wowauctions.resolve_build_id
+    """Redeploy is confirmed via a sentinel item, not raw 404 counting."""
+
+    def setUp(self):
+        self._orig_fetch = wowauctions.fetch_item
+        self._orig_resolve = wowauctions.resolve_build_id
+
+    def tearDown(self):
+        wowauctions.fetch_item = self._orig_fetch
+        wowauctions.resolve_build_id = self._orig_resolve
+
+    def test_sentinel_ok_means_no_reresolve(self):
+        # A no-data streak: the sentinel still returns data, so despite crossing
+        # the threshold we must NOT re-resolve or bump the generation.
+        wowauctions.fetch_item = lambda b, i: {"stats": {"avg_price": 5}}
+        wowauctions.resolve_build_id = lambda: (_ for _ in ()).throw(
+            AssertionError("resolve_build_id must not be called on a false alarm"))
+        state = backfill.BuildIdState("OLD", sentinel_id=4389)
+        for _ in range(3):
+            state.note_result(True, 3)
+        self.assertEqual(state.build_id, "OLD")
+        self.assertEqual(state.generation, 0)
+        self.assertEqual(state.consecutive_404, 0)
+
+    def test_sentinel_404_triggers_reresolve(self):
+        # Genuine redeploy: sentinel 404s under the current buildId and the new
+        # buildId differs -> re-resolve and bump generation.
+        wowauctions.fetch_item = lambda b, i: None
         wowauctions.resolve_build_id = lambda: "NEWBUILD"
-        try:
-            state = backfill.BuildIdState("OLD")
-            for _ in range(3):
-                state.note_result(True, 3)
-            self.assertEqual(state.build_id, "NEWBUILD")
-            self.assertEqual(state.generation, 1)
-            self.assertEqual(state.consecutive_404, 0)
-            state.note_result(False, 3)
-            self.assertEqual(state.consecutive_404, 0)
-        finally:
-            wowauctions.resolve_build_id = orig
+        state = backfill.BuildIdState("OLD", sentinel_id=4389)
+        for _ in range(3):
+            state.note_result(True, 3)
+        self.assertEqual(state.build_id, "NEWBUILD")
+        self.assertEqual(state.generation, 1)
+        self.assertEqual(state.consecutive_404, 0)
+
+    def test_sentinel_404_same_buildid_no_gen_bump(self):
+        # Sentinel 404s but re-resolution returns the same buildId (transient /
+        # sentinel genuinely gone) -> no generation bump, so no needless recovery.
+        wowauctions.fetch_item = lambda b, i: None
+        wowauctions.resolve_build_id = lambda: "OLD"
+        state = backfill.BuildIdState("OLD", sentinel_id=4389)
+        for _ in range(3):
+            state.note_result(True, 3)
+        self.assertEqual(state.build_id, "OLD")
+        self.assertEqual(state.generation, 0)
+
+    def test_non404_resets_counter(self):
+        state = backfill.BuildIdState("OLD")
+        state.note_result(True, 3)
+        state.note_result(True, 3)
+        self.assertEqual(state.consecutive_404, 2)
+        state.note_result(False, 3)
+        self.assertEqual(state.consecutive_404, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The redeploy heuristic re-resolved the wowauctions.net `buildId` after N consecutive 404s. But ~half of WotLK items legitimately have no ChromieCraft data (a normal 404), so long no-data streaks looked like redeploys. The real 20,721-item run hit `gen=181`, triggered a 9,005-item recovery re-fetch, and rate-limited the site into **3,175 false `fetch-failed`** results (~1,400 of which actually had prices). Those had to be salvaged with a manual gentle re-fetch.

## Fix

A genuine redeploy makes the current `buildId` 404 for **every** item, including ones that always have data. So after `--redeploy-threshold` consecutive 404s, verify with a known-good sentinel item (`--sentinel-id`, default 4389 = Gyrochronatom):

- Sentinel still returns data → buildId is fine, the 404s are genuine no-data → reset, no re-resolve.
- Sentinel also 404s → real redeploy → re-resolve, and bump the generation only if the buildId actually changed (so the recovery pass stays scoped).

Cost of a false alarm is now one cheap sentinel fetch per streak instead of a re-resolve storm.

## Tests

29 passing. `NoteResultTest` rewritten to cover: sentinel-ok (no re-resolve), sentinel-404 with changed buildId (re-resolve + gen bump), sentinel-404 with unchanged buildId (no gen bump), and counter reset.