### PR TITLE
feat: natural bid/buyout spread for override items, saner outbid steps

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -157,6 +157,11 @@ AuctionHouseBot.WeightRecent = true
 # Tolerance factor for minimum price (e.g., 0.9 means prices can go down to 90% of minPrice)
 AuctionHouseBot.MinPriceTolerance = 0.95
 
+# Buyer outbid step, as a percentage of the current price, e.g. currentPrice + currentPrice * 5-15%.
+# Must have Min <= Max and Min > 0, otherwise the values are reset to their defaults.
+AuctionHouseBot.Buyer.BidIncrementMinPct = 5
+AuctionHouseBot.Buyer.BidIncrementMaxPct = 15
+
 ###############################################################################
 # AUCTION HOUSE BOT FILTERS PART 1
 #

--- a/planned_things.md
+++ b/planned_things.md
@@ -1,101 +1,19 @@
 # Planned Improvements and Features for AuctionHouseBot
 
-## 1. Dynamic Pricing Based on Supply and Demand
-- **Description**: Implement a dynamic pricing model that adjusts prices based on supply and demand.
-- **Details**: Increase prices for frequently sold items and decrease prices for rarely sold items.
-- **Status**: Planned
+Tracker for the original 10-item wishlist (items 11-20 were exact duplicates of 1-10 and have been folded in).
 
-## 2. Price History Analysis
-- **Description**: Analyze the price history of items to detect trends and adjust prices accordingly.
-- **Details**: Set higher prices for items with steadily increasing prices.
-- **Status**: Planned
+## Covered
 
-## 3. Competitive Pricing
-- **Description**: Implement competitive pricing strategies where the bot adjusts its prices based on the prices of similar items listed by other players.
-- **Details**: Ensure the bot remains competitive in the market.
-- **Status**: Planned
+- Competitive pricing: ChromieCraft market-price overrides (PRs #11, #13, #15).
+- Inventory management: per-item listing count overrides (PRs #16, #17, #18) and reasonable stack sizes (PR #19).
+- Item rarity consideration: per-rarity price/bid ratio config exists upstream and is retained.
+- Market analysis: wowauctions.net backfill toolchain (tools/price-backfill).
 
-## 4. Time-Based Pricing Adjustments
-- **Description**: Adjust prices based on the time of day or day of the week.
-- **Details**: Set higher prices during peak hours and lower prices during off-peak hours.
-- **Status**: Planned
+## In progress
 
-## 5. Inventory Management
-- **Description**: Implement inventory management to ensure the bot does not flood the market with too many of the same item.
-- **Details**: Maintain a healthy supply and demand balance.
-- **Status**: Planned
+- Dynamic supply/demand pricing, price history analysis, user feedback integration: player-reactive demand multiplier, feat/demand-multiplier branch. The auction_history capture and moving-average pricing already merged cover the history-analysis foundation.
+- Bid increment strategy, buyout price strategy: this branch, feat/bid-buyout-refinement.
 
-## 6. Bid Increment Strategy
-- **Description**: Implement a strategy for setting bid increments.
-- **Details**: Set bid increments based on a percentage of the current bid price.
-- **Status**: Planned
+## Deferred
 
-## 7. Buyout Price Strategy
-- **Description**: Implement a strategy for setting buyout prices.
-- **Details**: Set buyout prices based on a percentage above the average bid price.
-- **Status**: Planned
-
-## 8. Item Rarity Consideration
-- **Description**: Consider the rarity of items when setting prices.
-- **Details**: Set higher prices for rare items compared to common items.
-- **Status**: Planned
-
-## 9. Market Analysis
-- **Description**: Perform market analysis to identify high-demand items and prioritize listing those items.
-- **Details**: Maximize profits by focusing on high-demand items.
-- **Status**: Planned
-
-## 10. User Feedback Integration
-- **Description**: Integrate user feedback to adjust prices.
-- **Details**: Use player purchase behavior to inform future pricing decisions.
-- **Status**: Planned
-
-## 11. Dynamic Pricing Based on Supply and Demand
-- **Description**: Adjust prices based on the number of items sold.
-- **Details**: Increase prices for high-demand items and decrease prices for low-demand items.
-- **Status**: Planned
-
-## 12. Price History Analysis
-- **Description**: Analyze historical price data to identify trends.
-- **Details**: Adjust prices based on historical trends.
-- **Status**: Planned
-
-## 13. Competitive Pricing
-- **Description**: Adjust prices based on competitor listings.
-- **Details**: Ensure the bot's prices are competitive with other sellers.
-- **Status**: Planned
-
-## 14. Time-Based Pricing Adjustments
-- **Description**: Adjust prices based on the time of day or day of the week.
-- **Details**: Set higher prices during peak hours and lower prices during off-peak hours.
-- **Status**: Planned
-
-## 15. Inventory Management
-- **Description**: Manage inventory to avoid flooding the market.
-- **Details**: Limit the number of items listed at any given time.
-- **Status**: Planned
-
-## 16. Bid Increment Strategy
-- **Description**: Set bid increments based on a percentage of the current bid price.
-- **Details**: Ensure bid increments are reasonable and competitive.
-- **Status**: Planned
-
-## 17. Buyout Price Strategy
-- **Description**: Set buyout prices based on a percentage above the average bid price.
-- **Details**: Ensure buyout prices are attractive to buyers.
-- **Status**: Planned
-
-## 18. Item Rarity Consideration
-- **Description**: Set prices based on item rarity.
-- **Details**: Higher prices for rare items, lower prices for common items.
-- **Status**: Planned
-
-## 19. Market Analysis
-- **Description**: Identify high-demand items and prioritize listing them.
-- **Details**: Focus on items that are in high demand to maximize profits.
-- **Status**: Planned
-
-## 20. User Feedback Integration
-- **Description**: Adjust prices based on user feedback and purchase behavior.
-- **Details**: Use data from player purchases to inform pricing decisions.
-- **Status**: Planned
+- Time-based pricing adjustments: low value on a low-population realm.

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1002,7 +1002,18 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
         if (avgPrice > 0 || minPrice > 0)
         {
             baseBuyoutPrice = avgPrice;
-            baseBidPrice = minPrice;
+            baseBidPrice = baseBuyoutPrice * urand(config->GetMinBidPrice(prototype->Quality), config->GetMaxBidPrice(prototype->Quality)) / 100;
+
+            // Respect the curated floor from the override, but never exceed buyout
+            if (baseBidPrice < minPrice)
+            {
+                baseBidPrice = minPrice;
+            }
+
+            if (baseBidPrice > baseBuyoutPrice)
+            {
+                baseBidPrice = baseBuyoutPrice;
+            }
         }
         else
         {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -504,9 +504,9 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
             continue;
         }
 
-        // Calculate our bid
-        double bidRate = static_cast<double>(urand(1, 100)) / 100;
-        double bidValue = currentPrice + ((maximumBid - currentPrice) * bidRate);
+        // Calculate our bid: step up from the current price by a small percentage,
+        // rather than leaping anywhere up to our maximum acceptable price.
+        double bidValue = currentPrice + (currentPrice * urand(config->GetBuyerBidIncrementMinPct(), config->GetBuyerBidIncrementMaxPct()) / 100.0);
         uint32 bidPrice = static_cast<uint32>(bidValue);
 
 
@@ -529,7 +529,6 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
         if (config->DebugOutBuyer)
         {
             LOG_INFO("module", "-------------------------------------------------");
-            LOG_INFO("module", "AHBot [{}]: Bid Rate: {}", _id, bidRate);
             LOG_INFO("module", "AHBot [{}]: Bid Value: {}", _id, bidValue);
             LOG_INFO("module", "AHBot [{}]: Bid Price: {}", _id, bidPrice);
             LOG_INFO("module", "AHBot [{}]: Minimum Outbid: {}", _id, minimumOutbid);

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -506,7 +506,7 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
 
         // Calculate our bid: step up from the current price by a small percentage,
         // rather than leaping anywhere up to our maximum acceptable price.
-        double bidValue = currentPrice + (currentPrice * urand(config->GetBuyerBidIncrementMinPct(), config->GetBuyerBidIncrementMaxPct()) / 100.0);
+        double bidValue = currentPrice + (static_cast<double>(currentPrice) * urand(config->GetBuyerBidIncrementMinPct(), config->GetBuyerBidIncrementMaxPct()) / 100.0);
         uint32 bidPrice = static_cast<uint32>(bidValue);
 
 

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -2093,7 +2093,7 @@ void AHBConfig::InitializeFromFile()
     BuyerBidIncrementMinPct        = sConfigMgr->GetOption<uint32>("AuctionHouseBot.Buyer.BidIncrementMinPct", 5);
     BuyerBidIncrementMaxPct        = sConfigMgr->GetOption<uint32>("AuctionHouseBot.Buyer.BidIncrementMaxPct", 15);
 
-    if (BuyerBidIncrementMinPct == 0 || BuyerBidIncrementMinPct > BuyerBidIncrementMaxPct)
+    if (BuyerBidIncrementMinPct == 0 || BuyerBidIncrementMinPct > BuyerBidIncrementMaxPct || BuyerBidIncrementMaxPct > 100)
     {
         LOG_WARN("module", "AHBConfig: invalid Buyer.BidIncrementMinPct/MaxPct ({}/{}), resetting to defaults 5/15", BuyerBidIncrementMinPct, BuyerBidIncrementMaxPct);
         BuyerBidIncrementMinPct = 5;

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -2089,6 +2089,16 @@ void AHBConfig::InitializeFromFile()
     WeightRecent                   = sConfigMgr->GetOption<bool>("AuctionHouseBot.WeightRecent", true);
     MinPriceTolerance              = sConfigMgr->GetOption<float>("AuctionHouseBot.MinPriceTolerance", 0.9f); // Default tolerance is 90% of minPrice
 
+    // Buyer outbid increment
+    BuyerBidIncrementMinPct        = sConfigMgr->GetOption<uint32>("AuctionHouseBot.Buyer.BidIncrementMinPct", 5);
+    BuyerBidIncrementMaxPct        = sConfigMgr->GetOption<uint32>("AuctionHouseBot.Buyer.BidIncrementMaxPct", 15);
+
+    if (BuyerBidIncrementMinPct == 0 || BuyerBidIncrementMinPct > BuyerBidIncrementMaxPct)
+    {
+        LOG_WARN("module", "AHBConfig: invalid Buyer.BidIncrementMinPct/MaxPct ({}/{}), resetting to defaults 5/15", BuyerBidIncrementMinPct, BuyerBidIncrementMaxPct);
+        BuyerBidIncrementMinPct = 5;
+        BuyerBidIncrementMaxPct = 15;
+    }
 
     // Flags: item types
     Vendor_Items                   = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.VendorItems"      , false);

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -310,6 +310,10 @@ public:
     bool WeightRecent;    // true to weight recent auctions more heavily
     float MinPriceTolerance; // Tolerance factor for minimum price
 
+    // Buyer outbid increment, as a percentage of the current price
+    uint32 BuyerBidIncrementMinPct;
+    uint32 BuyerBidIncrementMaxPct;
+
     // Constructors/destructors
     AHBConfig();
     AHBConfig(uint32 ahid, AHBConfig* conf);
@@ -388,6 +392,9 @@ public:
 
     uint32 GetNeutralBiddingInterval() const { return _neutralBiddingInterval; }
     uint32 GetNeutralBidsPerInterval() const { return _neutralBidsPerInterval; }
+
+    uint32 GetBuyerBidIncrementMinPct() const { return BuyerBidIncrementMinPct; }
+    uint32 GetBuyerBidIncrementMaxPct() const { return BuyerBidIncrementMaxPct; }
 };
 
 //


### PR DESCRIPTION
Stacked on #23 (retarget to merkerhood after that merges). Covers planned items 6 and 7.

## Bid/buyout spread for price-override items
Override items listed with `bid = minPrice` flat. They now get the same per-rarity bid-ratio spread as everything else: `bid = buyout * urand(MinBidPrice, MaxBidPrice)/100`, floored at the curated `minPrice` and capped at buyout. No new config.

## Buyer outbid increments
The bot's outbid step was `current + (maxAcceptable - current) * urand(1,100)%` — a uniform random leap that routinely overpaid and looked robotic. Now a percentage-of-current-price step: `current + current * urand(MinPct, MaxPct)%`, floored at the minimum legal outbid and capped at the max acceptable price, both unchanged from before. New config `AuctionHouseBot.Buyer.BidIncrementMinPct`/`MaxPct` (defaults 5/15, validated, capped at 100). Math promoted to double so high-value auctions (>~28k gold stacks) don't wrap 32-bit.

## planned_things.md
Deduped (items 11-20 were verbatim copies of 1-10) and each unique item marked Covered / In progress / Deferred with pointers to the PRs or branches that address it.

Compile-checked against the full core tree (RelWithDebInfo, gcc/ninja).